### PR TITLE
Fix the download URL for the Cassandra 3.0.18 release

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,7 @@ cp bin/cqlsh ${BUILD_DIR}/bin/
 
 echo "-----> Preparing cqlsh buildpack"
 CASSANDRA_DOWNLOAD_URL=$(test -f ${ENV_DIR}/CASSANDRA_DOWNLOAD_URL && cat ${ENV_DIR}/CASSANDRA_DOWNLOAD_URL)
-CASSANDRA_DOWNLOAD_URL=${CASSANDRA_DOWNLOAD_URL:-https://apache.claz.org/cassandra/3.0.17/apache-cassandra-3.0.17-bin.tar.gz}
+CASSANDRA_DOWNLOAD_URL=${CASSANDRA_DOWNLOAD_URL:-https://apache.claz.org/cassandra/3.0.18/apache-cassandra-3.0.18-bin.tar.gz}
 basename=$(basename $CASSANDRA_DOWNLOAD_URL)
 
 echo "-----> Downloading & unpacking cassandra"


### PR DESCRIPTION
Since the older version no longer exists at:
https://apache.claz.org/cassandra/